### PR TITLE
[AEROGEAR-2374] Remove labeling task and add label to the secret instead

### DIFF
--- a/roles/provision-unifiedpush-apb/tasks/main.yml
+++ b/roles/provision-unifiedpush-apb/tasks/main.yml
@@ -1,12 +1,3 @@
-- name: Get the name of the service instance
-  shell: oc get serviceinstance --namespace={{ namespace }} -o jsonpath='{.items[?(@.spec.externalID=="{{ _apb_service_instance_id }}")].metadata.name}'
-  when: _apb_service_instance_id is defined
-  register: service_instance_name
-
-- name: Label the service instance with the service name
-  shell: oc label serviceinstance '{{ service_instance_name.stdout }}' serviceName={{ ups_service_name }} --namespace={{ namespace }}
-  when: _apb_service_instance_id is defined
-
 - name: "Create OAuth Proxy Serviceaccount yaml"
   template:
     src: oauth-proxy-sa.yml.j2

--- a/roles/provision-unifiedpush-apb/tasks/provision-ups.yml
+++ b/roles/provision-unifiedpush-apb/tasks/provision-ups.yml
@@ -138,6 +138,13 @@
   template:
     src: secret.yml.j2
     dest: /tmp/secret.yaml
+  when: _apb_service_instance_id is defined
+
+- name: "Create ups secret-testing yaml file"
+  template:
+    src: secret-testing.yml.j2
+    dest: /tmp/secret.yaml
+  when: _apb_service_instance_id is not defined
 
 - name: "Create UPS secret"
   shell: "oc create -f /tmp/secret.yaml -n {{ namespace }}"

--- a/roles/provision-unifiedpush-apb/templates/secret-testing.yml.j2
+++ b/roles/provision-unifiedpush-apb/templates/secret-testing.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ ups_secret_name }}
+  namespace: {{ namespace }}
+  labels:
+    name: ups
+    mobile: enabled
+    serviceName: ups
+stringData:
+  type: {{ ups_secret_name }}
+  name: {{ ups_secret_name }}
+  uri: http://{{ ups_route.route.spec.host }}
+  applicationId: "{{ namespace_push_app.json.pushApplicationID }}"

--- a/roles/provision-unifiedpush-apb/templates/secret.yml.j2
+++ b/roles/provision-unifiedpush-apb/templates/secret.yml.j2
@@ -7,6 +7,7 @@ metadata:
     name: ups
     mobile: enabled
     serviceName: ups
+    serviceInstanceID: {{ _apb_service_instance_id }}
 stringData:
   type: {{ ups_secret_name }}
   name: {{ ups_secret_name }}


### PR DESCRIPTION
## Description
Add the serviceInstanceID label in the secret created during provision and remove the labeling task from provision.

## Progress
- [x] Remove the labeling task from the provision process
- [x] Add the label serviceInstanceID to the secret created during provision

## Verification Steps
- [x] Provision `Aerogear UPS` from the service catalog.
- [x] Verify that no labeling tasks are ran during the provision process.
- [x] Verify that the service is provisioned successfully.
- [x] Verify that the service instance has no `serviceName` label.
- [x] Verify that a `unified-push-server` secret has been created.
- [x] Verify that the label `serviceInstanceID` is included in this secrets yaml file.
- [x] Verify that the value of the `serviceInstanceID` matches with the service instance's `spec.externalID` value.

## Additional Notes
Related JIRA Ticket - https://issues.jboss.org/browse/AEROGEAR-2374