### PR TITLE
added variant ref to ios secret

### DIFF
--- a/roles/bind-unifiedpush-apb/tasks/main.yml
+++ b/roles/bind-unifiedpush-apb/tasks/main.yml
@@ -4,6 +4,10 @@
     dest: /tmp/secret.yaml
   when: googlekey is defined
 
+- name: "generate variant reference id"
+  shell: head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo ''
+  register: variant_reference_id
+
 - name: "Create ups secret yaml file"
   template:
     src: binding_secret_ios.yml.j2
@@ -30,4 +34,5 @@
       namespace: "{{ namespace }}"
       cert: "{{ cert }}"
       appType: "{{ type }}"
+      variantReferenceId: "{{ variant_reference_id.stdout }}"
   when: passphrase is defined

--- a/roles/bind-unifiedpush-apb/templates/binding_secret_ios.yml.j2
+++ b/roles/bind-unifiedpush-apb/templates/binding_secret_ios.yml.j2
@@ -12,3 +12,4 @@ stringData:
   clientId: "{{ clientId }}"
   passphrase: "{{ passphrase }}"
   cert: "{{ cert }}"
+  variantReferenceId: "{{ variant_reference_id.stdout }}"


### PR DESCRIPTION
Added a variant reference field to iOS secret to allow deleting of iOS configmap for variant

related Jira: https://issues.jboss.org/browse/AEROGEAR-2546  & pr https://github.com/aerogear/ups-config-operator/pull/28

ping @pb82 