### PR TITLE
prepare apb for config secret

### DIFF
--- a/roles/bind-unifiedpush-apb/tasks/main.yml
+++ b/roles/bind-unifiedpush-apb/tasks/main.yml
@@ -26,7 +26,7 @@
       namespace: "{{ namespace }}"
       googleKey: "{{ googlekey }}"
       appType: "{{ type }}"
-      variantReferenceId: "{{ variant_reference_id.stdout }}"
+      clientId: "{{ clientId }}"
   when: googlekey is defined
 
 - name: Store the iOS name of the binding secret to be used in unbind
@@ -35,5 +35,5 @@
       namespace: "{{ namespace }}"
       cert: "{{ cert }}"
       appType: "{{ type }}"
-      variantReferenceId: "{{ variant_reference_id.stdout }}"
+      clientId: "{{ clientId }}"
   when: passphrase is defined

--- a/roles/bind-unifiedpush-apb/templates/binding_secret_droid.yml.j2
+++ b/roles/bind-unifiedpush-apb/templates/binding_secret_droid.yml.j2
@@ -12,4 +12,3 @@ stringData:
   clientId: "{{ clientId }}"
   googleKey: "{{ googlekey }}"
   projectNumber: "{{ projectNumber }}"
-  variantReferenceId: "{{ variant_reference_id.stdout }}"

--- a/roles/bind-unifiedpush-apb/templates/binding_secret_ios.yml.j2
+++ b/roles/bind-unifiedpush-apb/templates/binding_secret_ios.yml.j2
@@ -12,4 +12,3 @@ stringData:
   clientId: "{{ clientId }}"
   passphrase: "{{ passphrase }}"
   cert: "{{ cert }}"
-  variantReferenceId: "{{ variant_reference_id.stdout }}"


### PR DESCRIPTION
Remove the variantReferenceId and use the clientId instead. We can do that now because we only have one config secret per mobile client, so the clientId is already unique.

Do not merge yet.