### PR TITLE
update to 2.1.0

### DIFF
--- a/apb.yml
+++ b/apb.yml
@@ -13,7 +13,7 @@ metadata:
   documentationUrl: "https://github.com/aerogearcatalog/unifiedpush-apb/blob/master/docs/modules/ups_openshift/index.asciidoc"
   providerDisplayName: "Red Hat, Inc."
   dependencies:
-    - "docker.io/aerogear/unifiedpush-wildfly-plain:2.0.2"
+    - "docker.io/aerogear/unifiedpush-wildfly-plain:2.1.0"
     - "docker.io/centos/postgresql-96-centos7:9.6"
     - "docker.io/aerogear/ups-config-operator:master"
     - "docker.io/openshift/oauth-proxy:v1.1.0"

--- a/roles/provision-unifiedpush-apb/defaults/main.yml
+++ b/roles/provision-unifiedpush-apb/defaults/main.yml
@@ -1,6 +1,6 @@
 # UPS Values
 ups_image: " docker.io/aerogear/unifiedpush-wildfly-plain"
-ups_image_tag: "2.0.2"
+ups_image_tag: "2.1.0"
 ups_port: 8080
 ups_proxy_port: 4180
 


### PR DESCRIPTION
Use the latest UPS version that contains the iOS Cert checking and other goodies.