### PR TITLE
add service instance name to secret

### DIFF
--- a/roles/bind-unifiedpush-apb/tasks/main.yml
+++ b/roles/bind-unifiedpush-apb/tasks/main.yml
@@ -10,6 +10,16 @@
   fail: msg="{{ CLIENT_ID  }} already has a variant of type {{ CLIENT_TYPE }}"
   when: existing_variant is defined and existing_variant.stdout != ""
 
+# Store the name of the service instance. It's required for some purposes like adding
+# annotations to the mobile client
+
+- name: "Get the name of the service insance"
+  shell: oc get serviceinstance --namespace={{ namespace }} -o jsonpath='{.items[?(@.spec.externalID=="{{ _apb_service_instance_id }}")].metadata.name}'
+  register: serviceinstance_name
+
+- set_fact:
+    UPS_NAME: "{{ serviceinstance_name.stdout }}"
+
 # The check has passed, no variant for this type seems to exist. Continue with
 # the binding secrets
 

--- a/roles/bind-unifiedpush-apb/templates/binding_secret_droid.yml.j2
+++ b/roles/bind-unifiedpush-apb/templates/binding_secret_droid.yml.j2
@@ -13,3 +13,4 @@ stringData:
   googleKey: "{{ googlekey }}"
   projectNumber: "{{ projectNumber }}"
   serviceBindingId: "{{ _apb_service_binding_id }}"
+  serviceInstanceName: "{{ UPS_NAME }}"

--- a/roles/bind-unifiedpush-apb/templates/binding_secret_ios.yml.j2
+++ b/roles/bind-unifiedpush-apb/templates/binding_secret_ios.yml.j2
@@ -14,3 +14,4 @@ stringData:
   cert: "{{ cert }}"
   isProduction: "{{ iosIsProduction }}"
   serviceBindingId: "{{ _apb_service_binding_id }}"
+  serviceInstanceName: "{{ UPS_NAME }}"


### PR DESCRIPTION
This adds the name of the UPS service instance to the secret and makes it available to the config operator. This is needed to create the correct names of the UI annotations.