### PR TITLE
allow custom service name for postgres

### DIFF
--- a/roles/provision-unifiedpush-apb/tasks/provision-ups.yml
+++ b/roles/provision-unifiedpush-apb/tasks/provision-ups.yml
@@ -34,6 +34,10 @@
           secret_key_ref:
             name: '{{ postgres_secret_name }}'
             key: database-name
+      - name: POSTGRES_SERVICE_HOST
+        value: "{{ postgres_service_name }}"
+      - name: POSTGRES_SERVICE_PORT
+        value: "5432"
       ports:
       - name: ups
         protocol: TCP

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,7 +4,7 @@ proxy_serviceaccount_name: "oauth-proxy"
 postgres_deploymentconfig_name: "postgres"
 postgres_pvc_name: "postgres-pvc"
 postgres_secret_name: "postgres-secret"
-postgres_service_name: "postgres"
+postgres_service_name: "ups-postgres"
 
 ups_deploymentconfig_name: "ups"
 ups_proxy_service_name: "ups-proxy"


### PR DESCRIPTION
Use the  `POSTGRES_SERVICE_HOST` env var to specify a custom host for postgres. Otherwise it will use `postgres://` by default which only resolves (on Kube/Openshift) if the service has excactly that name.

Verification steps:

1. Deploy keycloak-apb
1. Deploy unifiedpush-apb (this branch)
1. Both should deploy fine
1. Both admin UIs should be accessible
1. UPS push app for namespace should exist 