### PR TITLE
Make use of bindings limit

### DIFF
--- a/apb.yml
+++ b/apb.yml
@@ -22,6 +22,7 @@ metadata:
   sdk-docs-ios: "https://github.com/aerogearcatalog/unifiedpush-apb/blob/master/docs/modules/aerogear-push-ios/index.markdown"
   sdk-docs-xamarin: "https://github.com/aerogearcatalog/unifiedpush-apb/blob/master/docs/modules/aerogear-push-windows/index.markdown"
   serviceName: ups
+  bindingsLimit: 2
 plans:
   - name: default
     description: Persistent deployment of UPS


### PR DESCRIPTION
In MAR view on OpenShift web console, we didn't see the "Create Binding" button when there was a binding created already. But, the console's code is able to use a parameter from the APB, `bindingsLimit`.

It will keep showing that button until there are number of bindings defined with that parameter.

See the screenshot:

![screenshot from 2018-06-07 00-18-24](https://user-images.githubusercontent.com/376732/41065848-9ffae07a-69e8-11e8-83bc-378bf5bd636e.png)

If you want to verify this change, 
* build and push the apb from this branch
* do the deployment instructions at https://github.com/aerogear/ups-config-operator/pull/38
* do the verification instructions at https://github.com/aerogear/origin-web-console/pull/50
* create an Android binding
* you should still see the "Create Binding" button
* create an IOS binding
* that button should be hidden