### PR TITLE
dont require service binding id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ OiBpb3NJc1Byb2R1Y3Rpb24KICAgICAgdGl0bGU6IElzIHRoaXMgYSBwcm9kdWN0aW9uIGNlcnRp\
 ZmljYXRlPwogICAgICBkZWZhdWx0OiBmYWxzZQogICAgICB0eXBlOiBib29sZWFuCiAgICAgIGRp\
 c3BsYXlfdHlwZTogY2hlY2tib3gKICAgICAgZGlzcGxheV9ncm91cDogaU9TCg=="
 
+
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
 COPY vars /opt/ansible/vars

--- a/roles/bind-unifiedpush-apb/tasks/main.yml
+++ b/roles/bind-unifiedpush-apb/tasks/main.yml
@@ -1,9 +1,14 @@
 # Store the name of the service instance. It's required for some purposes like adding
 # annotations to the mobile client
 
-- name: "Get the name of the service insance"
+- name: "Get the name of the service instance"
   shell: oc get serviceinstance --namespace={{ namespace }} -o jsonpath='{.items[?(@.spec.externalID=="{{ _apb_service_instance_id }}")].metadata.name}'
   register: serviceinstance_name
+
+- name: "Ensure compatibility with older ASB versions"
+  set_fact:
+    _apb_service_binding_id: "DUMMY"
+  when: _apb_service_binding_id is not defined
 
 - set_fact:
     UPS_NAME: "{{ serviceinstance_name.stdout }}"

--- a/roles/provision-unifiedpush-apb/tasks/provision-ups.yml
+++ b/roles/provision-unifiedpush-apb/tasks/provision-ups.yml
@@ -118,7 +118,7 @@
   until: ups_result.stdout.find("3") != -1
   retries: 30
   delay: 5
-
+  
 - name: "Create {{ namespace }} PushApplication on service host {{ unifiedpush_service.service.spec.cluster_ip }}"
   uri:
     url: "http://{{ unifiedpush_service.service.spec.cluster_ip }}/rest/applications"
@@ -127,7 +127,7 @@
     validate_certs: no
     body_format: json
     status_code: 201
-  retries: 5
+  retries: 30
   until: namespace_push_app.status == 201
   delay: 5
   register: namespace_push_app


### PR DESCRIPTION
The Ansible Service Broker shipping with Openshift 3.9 doesn't pass the `_apb_service_binding_id` flag to the ansible roles (version 3.10+ will). This fix ensures makes sure bindings do not fail when this flag is not defined.

Everything should work normally except triggering unbind when a variant is deleted in UPS. You can still delete the bindings in Openshift as usual. 