### PR TITLE
Label the secret created during the bind operation

### DIFF
--- a/roles/bind-unifiedpush-apb/tasks/main.yml
+++ b/roles/bind-unifiedpush-apb/tasks/main.yml
@@ -10,8 +10,13 @@
     _apb_service_binding_id: "DUMMY"
   when: _apb_service_binding_id is not defined
 
+- name: Generate client id
+  shell: tr -d -c "a-zA-Z0-9" < /dev/urandom | head -c 20
+  register: generated_client_id
+
 - set_fact:
     UPS_NAME: "{{ serviceinstance_name.stdout }}"
+    GENERATED_CLIENT_ID: "{{ generated_client_id.stdout }}"
 
 # The check has passed, no variant for this type seems to exist. Continue with
 # the binding secrets

--- a/roles/bind-unifiedpush-apb/templates/binding_secret_droid.yml.j2
+++ b/roles/bind-unifiedpush-apb/templates/binding_secret_droid.yml.j2
@@ -7,6 +7,8 @@ metadata:
     name: "{{ CLIENT_ID }}-binding-secret"
     secretType: mobile-client-binding-secret
     mobile: enabled
+    serviceInstanceID: "{{ _apb_service_instance_id }}"
+    clientId: "{{ CLIENT_ID }}"
 stringData:
   appType: "{{ CLIENT_TYPE }}"
   clientId: "{{ CLIENT_ID }}"
@@ -14,3 +16,4 @@ stringData:
   projectNumber: "{{ projectNumber }}"
   serviceBindingId: "{{ _apb_service_binding_id }}"
   serviceInstanceName: "{{ UPS_NAME }}"
+  id: "{{ GENERATED_CLIENT_ID }}"

--- a/roles/bind-unifiedpush-apb/templates/binding_secret_ios.yml.j2
+++ b/roles/bind-unifiedpush-apb/templates/binding_secret_ios.yml.j2
@@ -7,6 +7,8 @@ metadata:
     name: "{{ CLIENT_ID }}-binding-secret"
     secretType: mobile-client-binding-secret
     mobile: enabled
+    serviceInstanceID: "{{ _apb_service_instance_id }}"
+    clientId: "{{ CLIENT_ID }}"
 stringData:
   appType: "{{ CLIENT_TYPE }}"
   clientId: "{{ CLIENT_ID }}"
@@ -15,3 +17,4 @@ stringData:
   isProduction: "{{ iosIsProduction }}"
   serviceBindingId: "{{ _apb_service_binding_id }}"
   serviceInstanceName: "{{ UPS_NAME }}"
+  id: "{{ GENERATED_CLIENT_ID }}"


### PR DESCRIPTION
# Motivation

https://issues.jboss.org/browse/AEROGEAR-7682

url, type, name and config are added to the data map of the secret by operator [1].

[1] https://github.com/aerogear/ups-config-operator/blob/master/pkg/configOperator/configOperator.go#L376-L379