### PR TITLE
Added "filterDisplayGroupBy":"CLIENT_TYPE" into the APB (required to filter the fields in the MDC UI)

### DIFF
--- a/apb.yml
+++ b/apb.yml
@@ -29,7 +29,7 @@ plans:
     free: True
     metadata:
       mobileclient_bind_parameters_data:
-        - '{"name": "CLIENT_ID", "value": "metadata.name", "type": "path"}'
+        - '{"name": "CLIENT_ID", "value": "metadata.name", "type": "path", "filterDisplayGroupBy":"CLIENT_TYPE"}'
     parameters: []
     bind_parameters:
     - name: CLIENT_ID


### PR DESCRIPTION
# Motivation
ISSUE: https://issues.jboss.org/browse/AEROGEAR-8133

Required by [PR139](https://github.com/aerogear/mobile-developer-console/pull/139)

# What
The filterDisplayGroupBy will be used inside the MDC UI to hide/show the field based on the selected platform (`android` or `iOS`)