### PR TITLE
fix: health check for ups

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,80 +3,56 @@
 // https://github.com/feedhenry/fh-pipeline-library
 @Library('fh-pipeline-library') _
 
-def repositoryName = "unifiedpush-apb"
-def projectName = "test-${repositoryName}-${currentBuild.number}-${currentBuild.startTimeInMillis}"
-
 stage('Trust') {
     enforceTrustedApproval('aerogear')
 }
 
 node ("ocp-slave") { 
+    def apb_container_id, pod_container_id, apb_pod_output
+    def apb_version = "sprint147.2"
+    
     stage('Cleanup') {
         deleteDir()
     }
+
     stage('Cloning the repo') {
         checkout scm
     }
 
-    try {
+    stage('Run APB test') {
+        apb_container_id = sh (
+            script: "docker run --detach --net=host --privileged -v \$PWD:/mnt -v \$HOME/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u \$UID docker.io/ansibleplaybookbundle/apb-tools:${apb_version} test --registry-route docker-registry.default.svc:5000",
+            returnStdout: true
+        ).trim()
+    }
+
+    stage('Watch the logs') {
+        
+        pod_container_id = sh (
+            script: "sleep 30 ; docker ps --filter since=${apb_container_id} | grep 'entrypoint.sh test' | awk '{print \$1}'",
+            returnStdout: true
+        ).trim()
+        
+        test_playbook_output = sh (
+            script: "docker logs -f ${pod_container_id}",
+            returnStdout: true
+        ).trim()
+        
+        echo test_playbook_output
+    }
     
-        stage('Create OpenShift project') {
-            sh script: "oc new-project ${projectName}"
-        }
-        stage('Build APB') {
-            try {
-                timeout(5) {
-                    sh script: """
-                    oc new-build --name ${repositoryName} --binary
-                    oc start-build ${repositoryName} --from-dir=.
-                    sleep 10
-                    oc logs -f bc/${repositoryName}
-                    """
-                }
-            } catch (Exception e) {
-                error "Build timed out"
-            }
+    stage('Get APB container logs and evaluate test result') {
 
-        }
+        apb_pod_output = sh (
+            // We must wait for APB container to finish. Otherwise `docker logs` command does not work.
+            script: "sleep 10 ; docker logs -f ${apb_container_id}",
+            returnStdout: true
+        ).trim()
 
-        stage('Add admin policy to serviceaccount "default"') {
-            sh script: "oc policy add-role-to-user admin --serviceaccount=default"
+        echo apb_pod_output
+        
+        if ( apb_pod_output.contains("Pod phase Failed") || !test_playbook_output.contains("failed=0") ) {
+            error("APB test failed.")
         }
-
-        stage('Test APB') {
-            try {
-                timeout(15) {
-                    sh script: """
-                    oc run testing-pod \
-                        --image=docker-registry.default.svc:5000/${projectName}/${repositoryName} \
-                        --restart=Never \
-                        --env POD_NAME=testing-pod \
-                        --env POD_NAMESPACE=${projectName} \
-                        --command -- \
-                        entrypoint.sh test --extra-vars '{\"namespace\": \"${projectName}\"}'
-                    sleep 10
-                    oc logs --pod-running-timeout=20s -f pod/testing-pod
-                    # Check if the status of testing-pod is error
-                    if [ \$(oc get pods | grep testing-pod | awk '{print \$3}') == "Error" ] ; then exit 1 ; fi
-                    """
-                }
-            } catch (Exception e) {
-                error "Pod didn't finish in time."
-            }
-        }
-        stage('Delete OpenShift project') {
-            sh script: "oc delete project ${projectName}"
-        }
-    } catch (Exception e) {
-        try {
-            timeout(15) {
-                input message: 'The test failed. Click on "Approve" to delete the project. Otherwise it will be deleted after 15 minutes'
-            }
-        } catch (Exception e2) {
-            println("Waiting for a user input exceeded its time limit. Deleting the project now.")
-        }
-
-        sh script: "oc delete project ${projectName}"
-        error "Error when running the test: ${e}"
     }
 }

--- a/roles/provision-unifiedpush-apb/tasks/provision-ups.yml
+++ b/roles/provision-unifiedpush-apb/tasks/provision-ups.yml
@@ -42,6 +42,12 @@
       - name: ups
         protocol: TCP
         container_port: 8080
+      readinessProbe:
+        httpGet:
+          path: '/rest/applications'
+          port: 8080
+        initialDelaySeconds: 15
+        timeoutSeconds: 2
     - name: ups-oauth-proxy
       image: '{{ proxy_image }}:{{ proxy_image_tag }}'
       imagePullPolicy: IfNotPresent
@@ -127,9 +133,6 @@
     validate_certs: no
     body_format: json
     status_code: 201
-  retries: 30
-  until: namespace_push_app.status == 201
-  delay: 5
   register: namespace_push_app
 
 # This is currently needed until https://github.com/openshift/ansible-service-broker/issues/847 is resolved


### PR DESCRIPTION
### Motivation
https://issues.jboss.org/browse/AEROGEAR-8743

By adding health check, we can be certain that the [command for creating ups app](https://github.com/aerogearcatalog/unifiedpush-apb/blob/7d5375966a5db8205d16a43ff8001fb6b6ed17f6/roles/provision-unifiedpush-apb/tasks/provision-ups.yml#L122-L133) is run only once.

<img width="543" alt="screenshot 2019-03-05 at 09 15 21" src="https://user-images.githubusercontent.com/4881144/53790456-47a85780-3f27-11e9-87f8-f06a0aec64a7.png">

<img width="797" alt="screenshot 2019-03-05 at 09 15 46" src="https://user-images.githubusercontent.com/4881144/53790464-4c6d0b80-3f27-11e9-99c1-38f2fa9e0fda.png">
